### PR TITLE
move views to separate module, MacOS compat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.py]
+indent_style = tab
+tab_width = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/bottle.py
+++ b/bottle.py
@@ -2,6 +2,7 @@ import random
 
 from cell import Cell
 from pill import Pill
+from views import Bottle as View
 
 class Bottle:
 	def __init__(self, other=None, width=8, height=16):
@@ -170,21 +171,3 @@ class Bottle:
 						self.cell_at(x+1, y).unbind()
 					cell.empty()
 
-class View:
-	def bottle_top(bottle):
-		spaces = " " * bottle.width
-		top = '═' * bottle.width * 1
-		return [
-			" %s╥      ╥%s " % (spaces, spaces),
-			"╔%s╝      ╚%s╗" % (top,top),
-		]
-
-	def lines(bottle):
-		rows = ["".join(str(c) for c in row) for row in bottle.cells]
-		cells = [("║%s\033[0m║" % row) for row in rows]
-		return [] + View.bottle_top(bottle) + cells + [
-			"╚" + "═" * bottle.width * 3 + "╝",
-		]
-
-	def render(bottle):
-		return "\n".join(View.lines(bottle)) + "\n"

--- a/cell.py
+++ b/cell.py
@@ -1,5 +1,7 @@
 import random
 
+from views import Cell as View
+
 class Cell:
 	EMPTY = 0
 	PILL = 1
@@ -67,36 +69,4 @@ class Cell:
 		return self.value & self.BIND_LEFT
 	def is_bound_right(self):
 		return self.value & self.BIND_RIGHT
-
-class View:
-	def ansi_color(cell):
-		return {
-			Cell.RED: "\033[0;30;41;4m",
-			Cell.YELLOW: "\033[0;30;43;4m",
-			Cell.BLUE: "\033[0;30;46;4m",
-			Cell.EMPTY: "\033[0;34;40m",
-		}[cell.color()]
-
-	def color_str(cell):
-		return {
-			Cell.RED: "▌Ѧ▐",
-			Cell.YELLOW: "▌Ѡ▐",
-			Cell.BLUE: "▌Ж▐",
-			Cell.EMPTY: "   ",
-		}[cell.color()]
-
-	def render(cell):
-		a = View.ansi_color(cell) 
-		c = View.color_str(cell)
-		if cell.is_zapped():
-			c = "\033[24;7m<◙>\033[27m"
-		elif cell.is_pill():
-			c = " "
-			if cell.is_bound_left():
-				c = " %s▐" % c
-			elif cell.is_bound_right():
-				c = "▌%s " % c
-			else:
-				c = "▌%s▐" % c
-		return "%s%s" % (a, c)
 

--- a/game.py
+++ b/game.py
@@ -4,6 +4,7 @@ import time
 
 from bottle import Bottle
 from pill import Pill
+from views import Game as View
 
 class State:
 	MOVING = 0
@@ -123,15 +124,4 @@ class Game:
 
 	def lose(self):
 		return self.state == State.LOSE
-
-class View:
-	def render(game):
-		next_pill = " " * game.bottle.width * 2 + "   " + str(game.next_pill)
-		bottle = "\n     ".join( game.bottle.lines() )
-		stats = ""
-		stats += "PILL " if game.pill is not None else "     "
-		stats += "STATE: %d " % game.state
-		stats += "VIRUS: %d " % game.bottle.virus_count()
-		stats += "COMBO: %d " % game.combo
-		return "     %s\n     %s\n%s" % (next_pill, bottle, stats)
 

--- a/main.py
+++ b/main.py
@@ -7,10 +7,6 @@ game = Game(10, 0)
 game.begin()
 game.toss_pill()
 
-def display():
-	term.clear()
-	print(str(game))
-
 while True:
 	key = term.getch()
 	if key:
@@ -28,11 +24,10 @@ while True:
 		if key in ('q', '\033'):
 			break
 
-		display()
-		print(key)
+		term.display(game)
 	
 	if game.tick():
-		display()
+		term.display(game)
 
 	if game.win():
 		print("YOU WIN!")

--- a/pill.py
+++ b/pill.py
@@ -1,4 +1,5 @@
 from cell import Cell
+from views import Pill as View
 
 class Pill:
 	LR = 0
@@ -67,8 +68,4 @@ class Pill:
 
 	def __str__(self):
 		return View.render(self)
-
-class View:
-	def render(pill):
-		return str(pill.cell1) + str(pill.cell2) + "\033[0m"
 

--- a/thread.py
+++ b/thread.py
@@ -1,0 +1,28 @@
+import threading
+import sys
+
+class KeyboardThread(threading.Thread):
+
+    def __init__(self, input_cbk = None, name='keyboard-input-thread'):
+        self.input_cbk = input_cbk
+        super(KeyboardThread, self).__init__(name=name)
+        self.start()
+
+    def run(self):
+        while True:
+            self.input_cbk(sys.stdin.read(1))
+            #self.input_cbk(input(1)) #waits to get input + Return
+
+showcounter = 0 #something to demonstrate the change
+
+def my_callback(inp):
+    #evaluate the keyboard input
+    print('You Entered:', inp, ' Counter is at:', showcounter)
+
+#start the Keyboard thread
+kthread = KeyboardThread(my_callback)
+
+while True:
+    #the normal program executes without blocking. here just counting up
+    showcounter += 1
+

--- a/views.py
+++ b/views.py
@@ -1,0 +1,67 @@
+
+class Game:
+	def render(game):
+		next_pill = " " * game.bottle.width * 2 + "   " + str(game.next_pill)
+		bottle = "\n     ".join( game.bottle.lines() )
+		stats = ""
+		stats += "PILL " if game.pill is not None else "     "
+		stats += "STATE: %d " % game.state
+		stats += "VIRUS: %d " % game.bottle.virus_count()
+		stats += "COMBO: %d " % game.combo
+		return "     %s\n     %s\n%s" % (next_pill, bottle, stats)
+
+class Bottle:
+	def bottle_top(bottle):
+		spaces = " " * bottle.width
+		top = '═' * bottle.width * 1
+		return [
+			" %s╥      ╥%s " % (spaces, spaces),
+			"╔%s╝      ╚%s╗" % (top,top),
+		]
+
+	def lines(bottle):
+		rows = ["".join(str(c) for c in row) for row in bottle.cells]
+		cells = [("║%s\033[0m║" % row) for row in rows]
+		return [] + Bottle.bottle_top(bottle) + cells + [
+			"╚" + "═" * bottle.width * 3 + "╝",
+		]
+
+	def render(bottle):
+		return "\n".join(Bottle.lines(bottle)) + "\n"
+
+class Cell:
+	def ansi_color(cell):
+		return {
+			cell.RED: "\033[0;30;41;4m",
+			cell.YELLOW: "\033[0;30;43;4m",
+			cell.BLUE: "\033[0;30;46;4m",
+			cell.EMPTY: "\033[0;34;40m",
+		}[cell.color()]
+
+	def color_str(cell):
+		return {
+			cell.RED: "▌Ѧ▐",
+			cell.YELLOW: "▌Ѡ▐",
+			cell.BLUE: "▌Ж▐",
+			cell.EMPTY: "   ",
+		}[cell.color()]
+
+	def render(cell):
+		a = Cell.ansi_color(cell)
+		c = Cell.color_str(cell)
+		if cell.is_zapped():
+			c = "\033[24;7m<◙>\033[27m"
+		elif cell.is_pill():
+			c = " "
+			if cell.is_bound_left():
+				c = " %s▐" % c
+			elif cell.is_bound_right():
+				c = "▌%s " % c
+			else:
+				c = "▌%s▐" % c
+		return "%s%s" % (a, c)
+
+class Pill:
+	def render(pill):
+		return str(pill.cell1) + str(pill.cell2) + "\033[0m"
+


### PR DESCRIPTION
Neatly consolidates all ANSI string formatting to `views` module.

Resolves #1 by temporarily disabling non-blocking input when writing to standard out.